### PR TITLE
Nitpick: Assume `-w` when `--build-watch-path` has been set

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -175,7 +175,7 @@ export default function parseArgv(raw: string[]): Options {
     buildCommand: argv["build-command"],
     buildBasePath: argv["build-base-path"],
     buildWatchPath: argv["build-watch-path"],
-    watch: argv.watch,
+    watch: argv.watch ||!!argv["build-watch-path"],
     host: argv.host,
     port: argv.port,
     upstream: argv.upstream,


### PR DESCRIPTION
This is an absolutely incredibly well done local testbed for Workers. I got it working on a Typescript Durable Object project with an install and a run command. Well done!

My *only* gripe so far has been that I had set only `--build-watch-path`, but I also had to set `-w` to get it to reload. This PR should fix that :)