### PR TITLE
Replace TOML parser to support dotted keys in wrangler.toml

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
+        "@iarna/toml": "^2.2.5",
         "@mrbbot/node-fetch": "^4.2.0",
         "@mrbbot/parsed-html-rewriter": "^0.1.8",
         "@peculiar/webcrypto": "^1.1.4",
@@ -25,7 +26,6 @@
         "selfsigned": "^1.10.11",
         "semver": "^7.3.5",
         "source-map-support": "^0.5.19",
-        "toml": "^3.0.0",
         "tslib": "^2.3.0",
         "typescript": "^4.3.4",
         "typeson": "^6.1.0",
@@ -432,6 +432,11 @@
       "resolved": "https://registry.npmjs.org/@francoischalifour/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.0.0-alpha.28.tgz",
       "integrity": "sha512-bprfNmYt1opFUFEtD2XfY/kEsm13bzHQgU80uMjhuK0DJ914IjolT1GytpkdM6tJ4MBvyiJPP+bTtWO+BZ7c7w==",
       "dev": true
+    },
+    "node_modules/@iarna/toml": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
     },
     "node_modules/@mrbbot/node-fetch": {
       "version": "4.2.0",
@@ -6323,11 +6328,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/toml": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
-      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
-    },
     "node_modules/totalist": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/totalist/-/totalist-1.1.0.tgz",
@@ -7259,6 +7259,11 @@
       "resolved": "https://registry.npmjs.org/@francoischalifour/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.0.0-alpha.28.tgz",
       "integrity": "sha512-bprfNmYt1opFUFEtD2XfY/kEsm13bzHQgU80uMjhuK0DJ914IjolT1GytpkdM6tJ4MBvyiJPP+bTtWO+BZ7c7w==",
       "dev": true
+    },
+    "@iarna/toml": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
     },
     "@mrbbot/node-fetch": {
       "version": "4.2.0",
@@ -11706,11 +11711,6 @@
       "requires": {
         "is-number": "^7.0.0"
       }
-    },
-    "toml": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
-      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
     },
     "totalist": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "miniflare": "dist/src/bootstrap.js"
   },
   "dependencies": {
+    "@iarna/toml": "^2.2.5",
     "@mrbbot/node-fetch": "^4.2.0",
     "@mrbbot/parsed-html-rewriter": "^0.1.8",
     "@peculiar/webcrypto": "^1.1.4",
@@ -49,7 +50,6 @@
     "selfsigned": "^1.10.11",
     "semver": "^7.3.5",
     "source-map-support": "^0.5.19",
-    "toml": "^3.0.0",
     "tslib": "^2.3.0",
     "typescript": "^4.3.4",
     "typeson": "^6.1.0",

--- a/src/options/wrangler.ts
+++ b/src/options/wrangler.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import path from "path";
-import toml from "toml";
+import toml from "@iarna/toml";
 import { DurableObjectOptions, ModuleRuleType, Options } from "./index";
 
 interface WranglerEnvironmentConfig {
@@ -82,7 +82,7 @@ export function getWranglerOptions(
   env?: string
 ): Options {
   // Parse wrangler config and select correct environment
-  const config: WranglerConfig = toml.parse(input);
+  const config = (toml.parse(input) as unknown) as WranglerConfig;
   if (env && config.env && env in config.env) {
     Object.assign(config, config.env[env]);
   }


### PR DESCRIPTION
Hi. 👋🏻 

It seems `toml` module does not support some TOML features like dotted keys.

> https://github.com/BinaryMuse/toml-node/issues/51

For example,

```toml
[build]
upload.format = "service-worker"
command = "npm run build"
```

This ends up with `Unable to parse wrangler.toml: SyntaxError: Expected "=", [ \t] or [A-Za-z0-9_\-] but "." found.` error now. (Of course this is valid TOML for `wrangler` CLI.)

And also `toml` module is not actively maintained, so why not use another implementation? 👀 