### PR TITLE
adds a 🔥favicon on all pages

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -3,7 +3,17 @@ const pkg = require("../../package.json");
 module.exports = {
   title: "Miniflare",
   description: pkg.description,
-  head: [["meta", { property: "og:description", content: pkg.description }]],
+  head: [
+    [
+      "link",
+      {
+        rel: "icon",
+        href:
+          "data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🔥</text></svg>",
+      },
+    ],
+    ["meta", { property: "og:description", content: pkg.description }],
+  ],
   themeConfig: {
     repo: "mrbbot/miniflare",
     docsDir: "docs",

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 ---
-title: 🔥 Home
+title: Home
 ---
 
 # 🔥 Miniflare


### PR DESCRIPTION
This commit adds a 🔥favicon on all pages via vitepress' config. It also removes it from the root page's title (so as to avoid two flames in a row). I used [this guide](https://css-tricks.com/emojis-as-favicons/).

Screenshots: 
![image](https://user-images.githubusercontent.com/18808/128892643-8374a684-9500-4b97-b335-0e2dcc4cb04d.png)

![image](https://user-images.githubusercontent.com/18808/128892594-3f1e3d88-fdae-4ff6-a4d2-54975d171680.png)

![image](https://user-images.githubusercontent.com/18808/128892689-f5476a35-a95b-4773-84a9-9bf034d3ca1e.png)
